### PR TITLE
332 display the response body of login and register api when 404 is thrown on react

### DIFF
--- a/dutluk/dutluk_frontend/src/components/Login.js
+++ b/dutluk/dutluk_frontend/src/components/Login.js
@@ -32,10 +32,10 @@ function LoginComponent({ onLogin }) {
         });
       })
       .catch((error) => {
-        if (error.response && error.response.status === 401) {
+        if (error.response) {
           messageApi.open({
             type: "error",
-            content: "Invalid username or password.",
+            content: error.response.data,
           });
         } else {
           messageApi.open({

--- a/dutluk/dutluk_frontend/src/components/Register.js
+++ b/dutluk/dutluk_frontend/src/components/Register.js
@@ -37,8 +37,17 @@ const RegisterComponent = () => {
       await messageApi.open({ type: "success", content: "Registered successfully!"});
       navigate("/login")
     } catch (error) {
-      console.error(error);
-      messageApi.open({ type: "error", content: "Error occurred during registration!"});
+      if (error.response) {
+        messageApi.open({
+          type: "error",
+          content: error.response.data,
+        });
+      } else {
+        messageApi.open({
+          type: "error",
+          content: "An error occurred while logging in.",
+        });
+      }
     }
   };
 


### PR DESCRIPTION
With this pr, we show error messages coming from the backend server (for login and register endpoints.)
If none is received (server down etc.), we show a standard error message.

closing #332