### PR TITLE
story id's coming from karadut now checked for deletion. Closes #419

### DIFF
--- a/dutluk/dutluk_backend/src/main/java/com/SWE573/dutluk_backend/service/StoryService.java
+++ b/dutluk/dutluk_backend/src/main/java/com/SWE573/dutluk_backend/service/StoryService.java
@@ -467,7 +467,12 @@ public class StoryService {
                 Story storyWithPercentage = addPercentageToStory(story, foundUser.getRecommendedStoriesMap().get(storyId));
                 storyList.add(storyWithPercentage);
             }
+            else{
+                recommendationMap.remove(storyId);
+            }
         }
+        foundUser.setRecommendedStoriesMap(recommendationMap);
+        userService.editUser(foundUser);
         return sortStoriesByDescending(storyList);
     }
 


### PR DESCRIPTION
story id's are now checked and if they don't exist, they are not added to the recommendedStoriesMap on user model.